### PR TITLE
add way to pass in API key in Shodanz.client.new initialization

### DIFF
--- a/lib/shodanz/client.rb
+++ b/lib/shodanz/client.rb
@@ -13,10 +13,18 @@ module Shodanz
     attr_reader :exploits_api
 
     # Create a new client to connect to any of the APIs.
-    def initialize
-      @rest_api      = Shodanz.api.rest.new
-      @streaming_api = Shodanz.api.streaming.new
-      @exploits_api  = Shodanz.api.exploits.new
+    #
+    # Optionally provide your shodan API key, or the environment
+    # variable SHODAN_API_KEY will be used.
+    def initialize(key: ENV['SHODAN_API_KEY'])
+      # pass the given API key to each of the underlying clients
+      #
+      # Note: you can optionally change these API keys later, if you
+      # had multiple for whatever reason. ;)
+      #
+      @rest_api      = Shodanz.api.rest.new(key: key)
+      @streaming_api = Shodanz.api.streaming.new(key: key)
+      @exploits_api  = Shodanz.api.exploits.new(key: key)
     end
   end
 end


### PR DESCRIPTION
Thanks @mateeuslinno!

Now the following is possible:
```ruby
client = Shodanz.client.new(key: "yourAPIkeyGOEShere")

# do stuff with client as you would normally
```