### PR TITLE
Migrate to async-rest

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 2
+

--- a/lib/shodanz.rb
+++ b/lib/shodanz.rb
@@ -25,12 +25,12 @@ module Shodanz
   def self.client
     Client
   end
-  
+
   def self.connect(**options)
     client = API::Rest.new(**options)
-    
+
     return client unless block_given?
-    
+
     begin
       Async do
         yield client

--- a/lib/shodanz.rb
+++ b/lib/shodanz.rb
@@ -2,6 +2,8 @@
 
 require 'json'
 require 'async'
+require 'async/rest/resource'
+require 'async/rest/representation'
 require 'async/http/internet'
 require 'shodanz/version'
 require 'shodanz/errors'

--- a/lib/shodanz.rb
+++ b/lib/shodanz.rb
@@ -25,4 +25,18 @@ module Shodanz
   def self.client
     Client
   end
+  
+  def self.connect(**options)
+    client = API::Rest.new(**options)
+    
+    return client unless block_given?
+    
+    begin
+      Async do
+        yield client
+      end.wait
+    ensure
+      client.close
+    end
+  end
 end

--- a/lib/shodanz/api.rb
+++ b/lib/shodanz/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'apis/utils.rb'
 require_relative 'apis/rest.rb'
 require_relative 'apis/streaming.rb'

--- a/lib/shodanz/api.rb
+++ b/lib/shodanz/api.rb
@@ -1,18 +1,30 @@
+require_relative 'apis/utils.rb'
 require_relative 'apis/rest.rb'
 require_relative 'apis/streaming.rb'
 require_relative 'apis/exploits.rb'
 
 module Shodanz
-  # There are 2 APIs for accessing Shodan: the REST API
-  # and the Streaming API. The REST API provides methods
-  # to search Shodan, look up hosts, get summary information
+  # There are 3 APIs for accessing Shodan: the REST API,
+  # the Streaming API and the Exploits API.
+
+  # The REST API provides methods to search Shodan,
+  # look up hosts, get summary information
   # on queries and a variety of utility methods to make
-  # developing easier. The Streaming API provides a raw,
+  # developing easier.
+  #
+  # The Streaming API provides a raw,
   # real-time feed of the data that Shodan is currently
   # collecting. There are several feeds that can be subscribed
   # to, but the data can't be searched or otherwise interacted
   # with; it's a live feed of data meant for large-scale
   # consumption of Shodan's information.
+  #
+  # The Exploits API provides access to several
+  # exploit/vulnerability data sources. At the moment,
+  # it searches across the following:
+  #  - Exploit DB
+  #  - Metasploit
+  #  - Common Vulnerabilities and Exposures (CVE)
   #
   # @author Kent 'picat' Gruber
   module API

--- a/lib/shodanz/apis/exploits.rb
+++ b/lib/shodanz/apis/exploits.rb
@@ -12,31 +12,21 @@ module Shodanz
     #  - Common Vulnerabilities and Exposures (CVE)
     #
     # @author Kent 'picat' Gruber
-    class Exploits
+    class Exploits < Representation
       include Shodanz::API::Utils
 
-      # @return [String]
-      attr_accessor :key
-
       # The path to the REST API endpoint.
-      URL = 'https://exploits.shodan.io/api/'
+      DEFAULT_URL = 'https://exploits.shodan.io/api/'
 
-      # @param key [String] SHODAN API key, defaulted to
-      # the *SHODAN_API_KEY* enviroment variable.
-      def initialize(key: ENV['SHODAN_API_KEY'])
-        @url      = URL
-        @internet = Async::HTTP::Internet.new
-        self.key  = key
+      # @param key [String] SHODAN API key, defaulted to the *SHODAN_API_KEY* enviroment variable.
+      def initialize(resource = nil, key: ENV['SHODAN_API_KEY'], metadata: {}, value: nil, wrapper: Wrapper::JSON.new)
+        # This is a little bit of a hack to support `Exploits.new` with no arguments.
+        if resource.nil?
+          reference = ::Protocol::HTTP::Reference.parse(DEFAULT_URL, key: key)
+          resource = Async::REST::Resource.for(reference)
+        end
 
-        warn 'No key has been found or provided!' unless key?
-      end
-
-      # Check if there's an API key.
-      # @return [String]
-      def key?
-        return true if @key
-
-        false
+        super(resource, metadata: metadata, value: value, wrapper: wrapper)
       end
 
       # Search across a variety of data sources for exploits and
@@ -50,7 +40,7 @@ module Shodanz
         params = turn_into_query(params)
         facets = turn_into_facets(facets)
         params[:page] = page
-        get('search', params.merge(facets))
+        get_value('search', params.merge(facets))
       end
 
       # This method behaves identical to the "/search" method with
@@ -62,7 +52,7 @@ module Shodanz
         params = turn_into_query(params)
         facets = turn_into_facets(params)
         params[:page] = page
-        get('count', params.merge(facets))
+        get_value('count', params.merge(facets))
       end
     end
   end

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -20,7 +20,7 @@ module Shodanz
             end
           end
 
-          return response
+          response
         end
 
         class Parser < ::Protocol::HTTP::Body::Wrapper

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -45,9 +45,7 @@ module Shodanz
       end
 
       def process_response(request, response)
-        unless response.success?
-          raise Shodanz::Errors::Error, response.read
-        end
+        raise Shodanz::Errors::Error, response.read unless response.success?
 
         message = super
 

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -19,10 +19,10 @@ module Shodanz
               warn "Unknown content type: #{content_type}!"
             end
           end
-          
+
           return response
         end
-        
+
         class Parser < ::Protocol::HTTP::Body::Wrapper
           def join
             ::JSON.parse(super, symbolize_names: false)
@@ -86,7 +86,7 @@ module Shodanz
           return value
         end
       end
-      
+
       def [] key
         if hash = to_hash
           hash[key.to_sym]

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -1,4 +1,4 @@
-# fronzen_string_literal: true
+# frozen_string_literal: true
 
 require 'json'
 require 'async/rest/representation'

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -1,0 +1,97 @@
+# fronzen_string_literal: true
+
+require 'json'
+require 'async/rest/representation'
+require 'async/rest/wrapper/json'
+require 'protocol/http/reference'
+
+module Shodanz
+  module API
+    module Wrapper
+      class JSON < Async::REST::Wrapper::JSON
+        def process_response(request, response)
+          if content_type = response.headers['content-type']
+            if content_type.start_with? @content_type
+              if body = response.body
+                response.body = Parser.new(body)
+              end
+            else
+              warn "Unknown content type: #{content_type}!"
+            end
+          end
+          
+          return response
+        end
+        
+        class Parser < ::Protocol::HTTP::Body::Wrapper
+          def join
+            ::JSON.parse(super, symbolize_names: false)
+          end
+        end
+      end
+    end
+
+    # Handle the general representation of the Shodanz API.
+    #
+    # @author Samuel Williams
+    class Representation < Async::REST::Representation
+      RATELIMIT = /rate limit reached/i
+      NOINFO = /no information available/i
+      NOQUERY = /empty search query/i
+
+      # Check if there's an API key.
+      def key?
+        @resource.parameters.include?('key')
+      end
+
+      def process_response(request, response)
+        unless response.success?
+          raise Shodanz::Errors::Error, response.read
+        end
+
+        message = super
+
+        if message.is_a?(Hash) and error = message['error']
+          case error
+          when RATELIMIT
+            raise Shodanz::Errors::RateLimited, error
+          when NOINFO
+            raise Shodanz::Errors::NoInformation, error
+          when NOQUERY
+            raise Shodanz::Errors::NoQuery, error
+          else
+            raise Shodanz::Errors::Error, error
+          end
+        end
+
+        return message
+      end
+
+      def representation
+        Representation
+      end
+
+      def represent(metadata, attributes)
+        resource = @resource.with(path: attributes[:id])
+
+        representation.new(resource, metadata: metadata, value: attributes)
+      end
+
+      def represent_message(message)
+        represent(message.headers, message.result)
+      end
+
+      def to_hash
+        if value.is_a?(Hash)
+          return value
+        end
+      end
+      
+      def [] key
+        if hash = to_hash
+          hash[key.to_sym]
+        end
+      end
+    end
+  end
+end

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -49,7 +49,7 @@ module Shodanz
 
         message = super
 
-        if message.is_a?(Hash) and error = message['error']
+        if message.is_a?(Hash) && (error = message['error'])
           case error
           when RATELIMIT
             raise Shodanz::Errors::RateLimited, error
@@ -62,7 +62,7 @@ module Shodanz
           end
         end
 
-        return message
+        message
       end
 
       def representation
@@ -80,15 +80,13 @@ module Shodanz
       end
 
       def to_hash
-        if value.is_a?(Hash)
-          return value
-        end
+        return value if value.is_a?(Hash)
       end
 
-      def [] key
-        if hash = to_hash
-          hash[key.to_sym]
-        end
+      def [](key)
+        return nil unless value.is_a?(Hash)
+
+        to_hash[key.to_sym]
       end
     end
   end

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -9,7 +9,7 @@ module Shodanz
   module API
     module Wrapper
       class JSON < Async::REST::Wrapper::JSON
-        def process_response(request, response)
+        def process_response(_request, response)
           if content_type = response.headers['content-type']
             if content_type.start_with? @content_type
               if body = response.body

--- a/lib/shodanz/apis/representation.rb
+++ b/lib/shodanz/apis/representation.rb
@@ -35,9 +35,9 @@ module Shodanz
     #
     # @author Samuel Williams
     class Representation < Async::REST::Representation
-      RATELIMIT = /rate limit reached/i
-      NOINFO = /no information available/i
-      NOQUERY = /empty search query/i
+      RATELIMIT = /rate limit reached/i.freeze
+      NOINFO = /no information available/i.freeze
+      NOQUERY = /empty search query/i.freeze
 
       # Check if there's an API key.
       def key?

--- a/lib/shodanz/apis/rest.rb
+++ b/lib/shodanz/apis/rest.rb
@@ -45,7 +45,7 @@ module Shodanz
             end
           end
         end
-        return hosts
+        hosts
       end
 
       # Returns all services that have been found on the given host IP.

--- a/lib/shodanz/apis/rest.rb
+++ b/lib/shodanz/apis/rest.rb
@@ -39,7 +39,7 @@ module Shodanz
         async do
           ips.each do |ip|
             Async do
-              h = host(ip)
+              h = host(ip, parameters)
               yield h if block_given?
               hosts << h
             end

--- a/lib/shodanz/apis/rest.rb
+++ b/lib/shodanz/apis/rest.rb
@@ -4,19 +4,6 @@ require_relative 'representation'
 
 module Shodanz
   module API
-    class Host < Representation
-    end
-    
-    class Hosts < Representation
-      def representation
-        Host
-      end
-      
-      def find_by_ip(ip, **parameters)
-        representation.new(@resource.with(path: ip, parameters: parameters))
-      end
-    end
-    
     # The REST API provides methods to search Shodan, look up
     # hosts, get summary information on queries and a variety
     # of other utilities. This requires you to have an API key

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -11,10 +11,10 @@ module Shodanz
       # Response ensures the parsed JSON body doesn't use symbols for key names.
       class Response < Async::REST::Representation
         class Parser < Protocol::HTTP::Body::Wrapper
-					def join
-						::JSON.parse(super, symbolize_names: false)
-					end
-				end
+          def join
+            ::JSON.parse(super, symbolize_names: false)
+          end
+        end
 
         def process_response(request, response)
           if body = response.body

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -2,68 +2,11 @@
 
 module Shodanz
   module API
-    # Utils provides simply get, post, and slurp_stream functionality
-    # to the client. Under the hood they support both async and non-async
-    # usage. You should basically never need to use these methods directly.
+    # Utils provides some common methods used in the REST
+    # and Exploits API. You shouldn't need to use this module directly.
     #
     # @author Kent 'picat' Gruber
     module Utils
-      # Response ensures the parsed JSON body doesn't use symbols for key names.
-      class Response < Async::REST::Representation
-        class Parser < Protocol::HTTP::Body::Wrapper
-          def join
-            ::JSON.parse(super, symbolize_names: false)
-          end
-        end
-
-        def process_response(request, response)
-          if body = response.body
-            response.body = Parser.new(body)
-          end
-
-          return response
-        end
-      end
-
-      # Perform a direct GET HTTP request to the REST API.
-      def get(path, **params)
-        params = params.transform_keys(&:to_sym)
-
-        params[:key] = @key
-
-        task = Async::REST::Resource.for(@url) do |resource|
-          handle_any_json_errors(resource.with(path: path, parameters: params).get(Response).value)
-        end
-
-        task.wait unless Async::Task.current?
-      end
-
-      # Perform a direct POST HTTP request to the REST API.
-      def post(path, **params)
-        params = params.transform_keys(&:to_sym)
-
-        params[:key] = @key
-
-        task = Async::REST::Resource.for(@url) do |resource|
-          handle_any_json_errors(resource.with(path: path, parameters: params).post(Response).value)
-        end
-
-        task.wait unless Async::Task.current?
-      end
-
-      # Perform the main function of consuming the streaming API.
-      def slurp_stream(path, **params)
-        if Async::Task.current?
-          async_slurp_stream(path, params) do |result|
-            yield result
-          end
-        else
-          sync_slurp_stream(path, params) do |result|
-            yield result
-          end
-        end
-      end
-
       def turn_into_query(params)
         filters = params.reject { |key, _| key == :query }
         filters.each do |key, value|
@@ -84,57 +27,24 @@ module Shodanz
         facets.select { |key, _| key == :facets }
       end
 
-      private
+      def async(&block)
+        if task = Async::Task.current?
+          yield
+        else
+          Async do
+            result = yield
 
-      RATELIMIT = 'rate limit reached'
-      NOINFO    = 'no information available'
-      NOQUERY   = 'empty search query'
+            self.close
 
-      def handle_any_json_errors(json)
-        return json unless json.is_a?(Hash) && json.key?('error')
-
-        raise Shodanz::Errors::RateLimited if json['error'].casecmp(RATELIMIT) >= 0
-        raise Shodanz::Errors::NoInformation if json['error'].casecmp(NOINFO) >= 0
-        raise Shodanz::Errors::NoQuery if json['error'].casecmp(NOQUERY) >= 0
-
-        json
-      end
-
-      def slurper(path, **params)
-        # param keys should all be strings
-        params = params.transform_keys(&:to_s)
-        # check if limit
-        if (limit = params.delete('limit'))
-          counter = 0
-        end
-        # make GET request to server
-        resp = @internet.get("#{@url}#{path}?key=#{@key}", params)
-        # read body line-by-line
-        until resp.body.nil? || resp.body.empty?
-          resp.body.read.each_line do |line|
-            next if line.strip.empty?
-
-            yield JSON.parse(line)
-            if limit
-              counter += 1
-              resp.close if counter == limit
-            end
-          end
-        end
-      ensure
-        resp&.close
-      end
-
-      def async_slurp_stream(path, **params)
-        Async::Task.current.async do
-          slurper(path, params) { |data| yield data }
+            result
+          end.wait
         end
       end
 
-      def sync_slurp_stream(path, **params)
-        Async do
-          slurper(path, params) { |data| yield data }
-        end.wait
+      def get_value(path, parameters = nil)
+        async do
+          Representation.new(@resource.with(path: path, parameters: parameters), wrapper: @wrapper).value
+        end
       end
     end
   end

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -28,7 +28,7 @@ module Shodanz
       end
 
       def async(&block)
-        if task = Async::Task.current?
+        if Async::Task.current?
           yield
         else
           Async do

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -34,7 +34,7 @@ module Shodanz
           Async do
             result = yield
 
-            self.close
+            close
 
             result
           end.wait

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -1,4 +1,4 @@
-# fronzen_string_literal: true
+# frozen_string_literal: true
 
 module Shodanz
   module API

--- a/lib/shodanz/errors.rb
+++ b/lib/shodanz/errors.rb
@@ -2,27 +2,32 @@
 
 module Shodanz
   module Errors
+    # A general Error from the Shodan API
     class Error < StandardError
     end
-    
+
+    # An error returned when the Shodan API is rate-limiting requests (1 per second)
     class RateLimited < Error
       def initialize(msg = 'Request rate limit reached (1 request/ second). Please wait a second before trying again and slow down your API calls.')
         super
       end
     end
 
+    # An error returned when there is no informational available from the API.
     class NoInformation < Error
       def initialize(msg = 'No information available.')
         super
       end
     end
 
+    # An error returned when here is no API key provided in the HTTP request to the API.
     class NoAPIKey < Error
       def initialize(msg = 'No API key has been found or provided! (setup your SHODAN_API_KEY environment variable)')
         super
       end
     end
 
+    # An error returned when there is no query in the HTTP request provided to the API.
     class NoQuery < Error
       def initialize(msg = 'Empty search query.')
         super

--- a/lib/shodanz/errors.rb
+++ b/lib/shodanz/errors.rb
@@ -2,25 +2,28 @@
 
 module Shodanz
   module Errors
-    class RateLimited < StandardError
+    class Error < StandardError
+    end
+    
+    class RateLimited < Error
       def initialize(msg = 'Request rate limit reached (1 request/ second). Please wait a second before trying again and slow down your API calls.')
         super
       end
     end
 
-    class NoInformation < StandardError
+    class NoInformation < Error
       def initialize(msg = 'No information available.')
         super
       end
     end
 
-    class NoAPIKey < StandardError
-      def initialize(msg = 'No API key has been found or provided! ( setup your SHODAN_API_KEY environment varialbe )')
+    class NoAPIKey < Error
+      def initialize(msg = 'No API key has been found or provided! (setup your SHODAN_API_KEY environment variable)')
         super
       end
     end
 
-    class NoQuery < StandardError
+    class NoQuery < Error
       def initialize(msg = 'Empty search query.')
         super
       end

--- a/shodanz.gemspec
+++ b/shodanz.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'async-rest', '~> 0.8.1'
 
   spec.add_development_dependency 'async-rspec', '~> 1.12.1'
-  spec.add_development_dependency 'bundler', '~> 1.17.2'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry', '~> 0.12.2'
   spec.add_development_dependency 'rake', '~> 12.3.2'
   spec.add_development_dependency 'rb-readline', '~> 0.5.5'

--- a/shodanz.gemspec
+++ b/shodanz.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'async', '~> 1.17.1'
   spec.add_dependency 'async-http', '~> 0.41'
+  spec.add_dependency 'async-rest', '~> 0.8.1'
 
   spec.add_development_dependency 'async-rspec', '~> 1.12.1'
   spec.add_development_dependency 'bundler', '~> 1.17.2'

--- a/shodanz.gemspec
+++ b/shodanz.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'async', '~> 1.17.1'
-  spec.add_dependency 'async-http', '~> 0.38.1'
+  spec.add_dependency 'async-http', '~> 0.41'
 
   spec.add_development_dependency 'async-rspec', '~> 1.12.1'
   spec.add_development_dependency 'bundler', '~> 1.17.2'

--- a/spec/exploits_api_spec.rb
+++ b/spec/exploits_api_spec.rb
@@ -1,4 +1,6 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Shodanz::API::Exploits do
   before do
@@ -14,7 +16,7 @@ RSpec.describe Shodanz::API::Exploits do
       subject.close
     end
 
-    let(:resp) {subject.search("SQL", port: 443)}
+    let(:resp) { subject.search('SQL', port: 443) }
 
     it 'search across a variety of data sources for exploits' do
       expect(resp).to be_a(Hash)
@@ -28,7 +30,7 @@ RSpec.describe Shodanz::API::Exploits do
       subject.close
     end
 
-    let(:resp) {subject.count("SQL", port: 443)}
+    let(:resp) { subject.count('SQL', port: 443) }
 
     it 'gives the count from the #search method' do
       expect(resp).to be_a(Hash)

--- a/spec/exploits_api_spec.rb
+++ b/spec/exploits_api_spec.rb
@@ -2,30 +2,36 @@ require "spec_helper"
 
 RSpec.describe Shodanz::API::Exploits do
   before do
-    @client = Shodanz.api.exploits.new
+    # try to avoid rate limit
+    sleep 1
   end
 
   # this seems to take a very long time
-  #describe '#search' do
-  #  def check
-  #    if Async::Task.current?
-  #      resp = @client.search("SQL", port: 443).wait
-  #    else
-  #      resp = @client.search("SQL", port: 443)
-  #    end
-  #    expect(resp).to be_a(Hash)
-  #  end
+  describe '#search' do
+    include_context Async::RSpec::Reactor
 
-  #  describe 'search across a variety of data sources for exploits' do
-  #    it 'works synchronously' do
-  #      check
-  #    end
+    after do
+      subject.close
+    end
 
-  #    it 'works asynchronously' do
-  #      Async do
-  #        check
-  #      end
-  #    end
-  #  end
-  #end
+    let(:resp) {subject.search("SQL", port: 443)}
+
+    it 'search across a variety of data sources for exploits' do
+      expect(resp).to be_a(Hash)
+    end
+  end
+
+  describe '#count' do
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
+    end
+
+    let(:resp) {subject.count("SQL", port: 443)}
+
+    it 'gives the count from the #search method' do
+      expect(resp).to be_a(Hash)
+    end
+  end
 end

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -1,4 +1,6 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Shodanz::API::REST do
   before do
@@ -13,11 +15,11 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:info) {subject.info}
+    let(:info) { subject.info }
 
     it 'returns info about the underlying token' do
       expect(info).to be_a Hash
-      expect(info).to include("scan_credits", "usage_limits")
+      expect(info).to include('scan_credits', 'usage_limits')
     end
   end
 
@@ -28,7 +30,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:resp) { subject.host("8.8.8.8") }
+    let(:resp) { subject.host('8.8.8.8') }
 
     it 'returns all services that have been found on the given host IP' do
       expect(resp).to be_a(Hash)
@@ -42,7 +44,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:resp) { subject.host_count("apache") }
+    let(:resp) { subject.host_count('apache') }
 
     it 'returns the total number of results that matches a given query' do
       expect(resp).to be_a(Hash)
@@ -56,7 +58,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:resp) { subject.host_search("apache") }
+    let(:resp) { subject.host_search('apache') }
 
     it 'returns the total number of results that matches a given query' do
       expect(resp).to be_a(Hash)
@@ -70,7 +72,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:query) { "apache" }
+    let(:query) { 'apache' }
 
     let(:resp) { subject.host_search_tokens(query) }
 
@@ -123,10 +125,10 @@ RSpec.describe Shodanz::API::REST do
 
     it 'returns information about the shodan account' do
       expect(resp).to be_a(Hash)
-      expect(resp["member"]).to be(true).or be(false)
-      expect(resp["credits"]).to be_a(Integer)
-      expect(resp["created"]).to be_a(String)
-      expect(resp.key?("display_name")).to be(true)
+      expect(resp['member']).to be(true).or be(false)
+      expect(resp['credits']).to be_a(Integer)
+      expect(resp['created']).to be_a(String)
+      expect(resp.key?('display_name')).to be(true)
     end
   end
 
@@ -162,7 +164,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:resp) { subject.search_for_community_query("apache") }
+    let(:resp) { subject.search_for_community_query('apache') }
 
     it 'search the directory of search queries that users have saved' do
       expect(resp).to be_a(Hash)
@@ -187,7 +189,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:resp) { subject.resolve("google.com") }
+    let(:resp) { subject.resolve('google.com') }
 
     it 'resolves domains to ip addresses' do
       expect(resp).to be_a(Hash)
@@ -201,7 +203,7 @@ RSpec.describe Shodanz::API::REST do
       subject.close
     end
 
-    let(:ip) { "8.8.8.8" }
+    let(:ip) { '8.8.8.8' }
 
     let(:resp) { subject.reverse_lookup(ip) }
 
@@ -223,12 +225,12 @@ RSpec.describe Shodanz::API::REST do
 
     it 'shows the HTTP headers that your client sends when connecting to a webserver' do
       expect(resp).to be_a(Hash)
-      # TODO figure out why there are two content length headers?
+      # TODO: figure out why there are two content length headers?
       expect(resp['Content_Length']).to be_a(String)
       expect(resp['Content_Length']).to eq('0')
       expect(resp['Content-Length']).to be_a(String)
       expect(resp['Content-Length']).to eq('0')
-      # TODO maybe specify a content-type?
+      # TODO: maybe specify a content-type?
       expect(resp['Content-Type']).to be_a(String)
       expect(resp['Content-Type']).to eq('')
       expect(resp['Host']).to be_a(String)

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -22,89 +22,59 @@ RSpec.describe Shodanz::API::REST do
   end
 
   describe '#host' do
-    let(:ip) { "8.8.8.8" }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.host(ip).wait
-      else
-        resp = subject.host(ip)
-      end
-      expect(resp).to be_a(Hash)
+    after do
+      subject.close
     end
 
-    describe 'returns all services that have been found on the given host IP' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.host("8.8.8.8") }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'returns all services that have been found on the given host IP' do
+      expect(resp).to be_a(Hash)
     end
   end
 
   describe '#host_count' do
-    let(:query) { "apache" }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.host_count(query).wait
-      else
-        resp = subject.host_count(query)
-      end
-      expect(resp).to be_a(Hash)
+    after do
+      subject.close
     end
 
-    describe 'returns the total number of results that matches a given query' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.host_count("apache") }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'returns the total number of results that matches a given query' do
+      expect(resp).to be_a(Hash)
     end
   end
 
   describe '#host_search' do
-    let(:query) { "apache" }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.host_search(query).wait
-      else
-        resp = subject.host_search(query)
-      end
-      expect(resp).to be_a(Hash)
+    after do
+      subject.close
     end
 
-    describe 'returns the total number of results that matches a given query' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.host_search("apache") }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'returns the total number of results that matches a given query' do
+      expect(resp).to be_a(Hash)
     end
   end
 
   describe '#host_search_tokens' do
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
+    end
+
     let(:query) { "apache" }
 
-    def check
-      if Async::Task.current?
-        resp = subject.host_search_tokens(query).wait
-      else
-        resp = subject.host_search_tokens(query)
-      end
+    let(:resp) { subject.host_search_tokens(query) }
+
+    it 'returns a parsed version of the query' do
       expect(resp).to be_a(Hash)
       expect(resp['attributes']).to be_a(Hash)
       expect(resp['errors']).to be_a(Array)
@@ -112,100 +82,64 @@ RSpec.describe Shodanz::API::REST do
       expect(resp['string']).to be_a(String)
       expect(resp['string']).to eq(query)
     end
-
-    describe 'returns a parsed version of the query' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
-    end
   end
 
   describe '#ports' do
-    def check
-      if Async::Task.current?
-        resp = subject.ports.wait
-      else
-        resp = subject.ports
-      end
-      expect(resp).to be_a(Array)
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
     end
 
-    describe 'returns a list of port numbers that the crawlers are looking for' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.ports }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'returns a list of port numbers that the crawlers are looking for' do
+      expect(resp).to be_a(Array)
     end
   end
 
   describe '#protocols' do
-    def check
-      if Async::Task.current?
-        resp = subject.protocols.wait
-      else
-        resp = subject.protocols
-      end
-      expect(resp).to be_a(Hash)
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
     end
 
-    describe 'returns all protocols that can be used when performing on-demand scans' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.protocols }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'returns all protocols that can be used when performing on-demand scans' do
+      expect(resp).to be_a(Hash)
     end
   end
 
   describe '#profile' do
-    def check
-      if Async::Task.current?
-        resp = subject.profile.wait
-      else
-        resp = subject.profile
-      end
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
+    end
+
+    let(:resp) { subject.profile }
+
+    it 'returns information about the shodan account' do
       expect(resp).to be_a(Hash)
       expect(resp["member"]).to be(true).or be(false)
       expect(resp["credits"]).to be_a(Integer)
       expect(resp["created"]).to be_a(String)
       expect(resp.key?("display_name")).to be(true)
     end
-
-    describe 'returns information about the shodan account' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
-    end
   end
 
   describe '#community_queries' do
-    def check
-      if Async::Task.current?
-        resp = subject.community_queries.wait
-      else
-        resp = subject.community_queries
-      end
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
+    end
+
+    let(:resp) { subject.community_queries }
+
+    it 'obtains a list of search queries that users have saved' do
       expect(resp).to be_a(Hash)
       expect(resp['total']).to be_a(Integer)
       expect(resp['matches']).to be_a(Array)
@@ -218,30 +152,19 @@ RSpec.describe Shodanz::API::REST do
       expect(example_match['timestamp']).to be_a(String)
       expect(example_match['title']).to be_a(String)
       expect(example_match['query']).to be_a(String)
-    end
-
-    describe 'obtains a list of search queries that users have saved' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
     end
   end
 
   describe '#search_for_community_query' do
-    let(:query) { "apache" }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.search_for_community_query(query).wait
-      else
-        resp = subject.search_for_community_query(query)
-      end
+    after do
+      subject.close
+    end
+
+    let(:resp) { subject.search_for_community_query("apache") }
+
+    it 'search the directory of search queries that users have saved' do
       expect(resp).to be_a(Hash)
       expect(resp['total']).to be_a(Integer)
       expect(resp['matches']).to be_a(Array)
@@ -255,79 +178,50 @@ RSpec.describe Shodanz::API::REST do
       expect(example_match['title']).to be_a(String)
       expect(example_match['query']).to be_a(String)
     end
-
-    describe 'search the directory of search queries that users have saved' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
-    end
   end
 
   describe '#resolve' do
-    let(:hostname) { "google.com" }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.resolve(hostname).wait
-      else
-        resp = subject.resolve(hostname)
-      end
-      expect(resp).to be_a(Hash)
+    after do
+      subject.close
     end
 
-    describe 'resolves domains to ip addresses' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.resolve("google.com") }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'resolves domains to ip addresses' do
+      expect(resp).to be_a(Hash)
     end
   end
 
   describe '#reverse_lookup' do
-    let(:ip) { '8.8.8.8' }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.reverse_lookup(ip).wait
-      else
-        resp = subject.reverse_lookup(ip)
-      end
+    after do
+      subject.close
+    end
+
+    let(:ip) { "8.8.8.8" }
+
+    let(:resp) { subject.reverse_lookup(ip) }
+
+    it 'resolves ip addresses to domains' do
       expect(resp).to be_a(Hash)
       expect(resp[ip]).to be_a(Array)
       expect(resp[ip].first).to eq('google-public-dns-a.google.com')
     end
-
-    describe 'resolves ip addresses to domains' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
-    end
   end
 
   describe '#http_headers' do
-    def check
-      if Async::Task.current?
-        resp = subject.http_headers.wait
-      else
-        resp = subject.http_headers
-      end
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
+    end
+
+    let(:resp) { subject.http_headers }
+
+    it 'shows the HTTP headers that your client sends when connecting to a webserver' do
       expect(resp).to be_a(Hash)
       # TODO figure out why there are two content length headers?
       expect(resp['Content_Length']).to be_a(String)
@@ -340,67 +234,34 @@ RSpec.describe Shodanz::API::REST do
       expect(resp['Host']).to be_a(String)
       expect(resp['Host']).to eq('api.shodan.io')
     end
-
-    describe 'shows the HTTP headers that your client sends when connecting to a webserver' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
-    end
   end
 
   describe '#my_ip' do
-    def check
-      if Async::Task.current?
-        resp = subject.my_ip.wait
-      else
-        resp = subject.my_ip
-      end
-      expect(resp).to be_a(String)
+    include_context Async::RSpec::Reactor
+
+    after do
+      subject.close
     end
 
-    describe 'shows the current IP address as seen from the internet' do
-      it 'works synchronously' do
-        check
-      end
+    let(:resp) { subject.my_ip }
 
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    it 'shows the current IP address as seen from the internet' do
+      expect(resp).to be_a(String)
     end
   end
 
   describe '#honeypot_score' do
-    let(:ip) { '8.8.8.8' }
+    include_context Async::RSpec::Reactor
 
-    def check
-      if Async::Task.current?
-        resp = subject.honeypot_score(ip).wait
-      else
-        resp = subject.honeypot_score(ip)
-      end
+    after do
+      subject.close
+    end
+
+    let(:resp) { subject.honeypot_score('8.8.8.8') }
+
+    it 'returns the calculated likelihood a given IP is a honeypot' do
       expect(resp).to be_a(Float)
       expect(resp).to eq(0.0)
     end
-
-    describe 'returns the calculated likelihood a given IP is a honeypot' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
-    end
   end
-
 end

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe Shodanz::API::REST do
 
   describe '#info' do
     include_context Async::RSpec::Reactor
-    
+
     after do
       subject.close
     end
-    
+
     let(:info) {subject.info}
-    
+
     it 'returns info about the underlying token' do
       expect(info).to be_a Hash
       expect(info).to include("scan_credits", "usage_limits")

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -2,34 +2,22 @@ require "spec_helper"
 
 RSpec.describe Shodanz::API::REST do
   before do
-    @client = Shodanz.api.rest.new
-  end
-
-  before(:each) do
     # try to avoid rate limit
     sleep 1
   end
 
   describe '#info' do
-    def check
-      if Async::Task.current?
-        resp = @client.info.wait
-      else
-        resp = @client.info
-      end
-      expect(resp).to be_a(Hash)
+    include_context Async::RSpec::Reactor
+    
+    after do
+      subject.close
     end
-
-    describe 'returns info about the underlying token' do
-      it 'works synchronously' do
-        check
-      end
-
-      it 'works asynchronously' do
-        Async do
-          check
-        end
-      end
+    
+    let(:info) {subject.info}
+    
+    it 'returns info about the underlying token' do
+      expect(info).to be_a Hash
+      expect(info).to include("scan_credits", "usage_limits")
     end
   end
 
@@ -38,9 +26,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.host(ip).wait
+        resp = subject.host(ip).wait
       else
-        resp = @client.host(ip)
+        resp = subject.host(ip)
       end
       expect(resp).to be_a(Hash)
     end
@@ -63,9 +51,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.host_count(query).wait
+        resp = subject.host_count(query).wait
       else
-        resp = @client.host_count(query)
+        resp = subject.host_count(query)
       end
       expect(resp).to be_a(Hash)
     end
@@ -88,9 +76,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.host_search(query).wait
+        resp = subject.host_search(query).wait
       else
-        resp = @client.host_search(query)
+        resp = subject.host_search(query)
       end
       expect(resp).to be_a(Hash)
     end
@@ -113,9 +101,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.host_search_tokens(query).wait
+        resp = subject.host_search_tokens(query).wait
       else
-        resp = @client.host_search_tokens(query)
+        resp = subject.host_search_tokens(query)
       end
       expect(resp).to be_a(Hash)
       expect(resp['attributes']).to be_a(Hash)
@@ -141,9 +129,9 @@ RSpec.describe Shodanz::API::REST do
   describe '#ports' do
     def check
       if Async::Task.current?
-        resp = @client.ports.wait
+        resp = subject.ports.wait
       else
-        resp = @client.ports
+        resp = subject.ports
       end
       expect(resp).to be_a(Array)
     end
@@ -164,9 +152,9 @@ RSpec.describe Shodanz::API::REST do
   describe '#protocols' do
     def check
       if Async::Task.current?
-        resp = @client.protocols.wait
+        resp = subject.protocols.wait
       else
-        resp = @client.protocols
+        resp = subject.protocols
       end
       expect(resp).to be_a(Hash)
     end
@@ -187,9 +175,9 @@ RSpec.describe Shodanz::API::REST do
   describe '#profile' do
     def check
       if Async::Task.current?
-        resp = @client.profile.wait
+        resp = subject.profile.wait
       else
-        resp = @client.profile
+        resp = subject.profile
       end
       expect(resp).to be_a(Hash)
       expect(resp["member"]).to be(true).or be(false)
@@ -214,9 +202,9 @@ RSpec.describe Shodanz::API::REST do
   describe '#community_queries' do
     def check
       if Async::Task.current?
-        resp = @client.community_queries.wait
+        resp = subject.community_queries.wait
       else
-        resp = @client.community_queries
+        resp = subject.community_queries
       end
       expect(resp).to be_a(Hash)
       expect(resp['total']).to be_a(Integer)
@@ -250,9 +238,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.search_for_community_query(query).wait
+        resp = subject.search_for_community_query(query).wait
       else
-        resp = @client.search_for_community_query(query)
+        resp = subject.search_for_community_query(query)
       end
       expect(resp).to be_a(Hash)
       expect(resp['total']).to be_a(Integer)
@@ -286,9 +274,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.resolve(hostname).wait
+        resp = subject.resolve(hostname).wait
       else
-        resp = @client.resolve(hostname)
+        resp = subject.resolve(hostname)
       end
       expect(resp).to be_a(Hash)
     end
@@ -311,9 +299,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.reverse_lookup(ip).wait
+        resp = subject.reverse_lookup(ip).wait
       else
-        resp = @client.reverse_lookup(ip)
+        resp = subject.reverse_lookup(ip)
       end
       expect(resp).to be_a(Hash)
       expect(resp[ip]).to be_a(Array)
@@ -336,9 +324,9 @@ RSpec.describe Shodanz::API::REST do
   describe '#http_headers' do
     def check
       if Async::Task.current?
-        resp = @client.http_headers.wait
+        resp = subject.http_headers.wait
       else
-        resp = @client.http_headers
+        resp = subject.http_headers
       end
       expect(resp).to be_a(Hash)
       # TODO figure out why there are two content length headers?
@@ -369,9 +357,9 @@ RSpec.describe Shodanz::API::REST do
   describe '#my_ip' do
     def check
       if Async::Task.current?
-        resp = @client.my_ip.wait
+        resp = subject.my_ip.wait
       else
-        resp = @client.my_ip
+        resp = subject.my_ip
       end
       expect(resp).to be_a(String)
     end
@@ -394,9 +382,9 @@ RSpec.describe Shodanz::API::REST do
 
     def check
       if Async::Task.current?
-        resp = @client.honeypot_score(ip).wait
+        resp = subject.honeypot_score(ip).wait
       else
-        resp = @client.honeypot_score(ip)
+        resp = subject.honeypot_score(ip)
       end
       expect(resp).to be_a(Float)
       expect(resp).to eq(0.0)

--- a/spec/shodanz_spec.rb
+++ b/spec/shodanz_spec.rb
@@ -1,7 +1,9 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Shodanz do
-  it "has a version number" do
+  it 'has a version number' do
     expect(Shodanz::VERSION).not_to be nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,14 @@
-require "bundler/setup"
-require "async/rspec"
-require "shodanz"
-require "pry"
-require "readline"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'async/rspec'
+require 'shodanz'
+require 'pry'
+require 'readline'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/streaming_api_spec.rb
+++ b/spec/streaming_api_spec.rb
@@ -1,4 +1,6 @@
-require "spec_helper"
+# frozen_string_literal: true
+
+require 'spec_helper'
 
 RSpec.describe Shodanz::API::Streaming do
   before do


### PR DESCRIPTION
This PR uses [`async-rest`](https://github.com/socketry/async-rest) to manage GET/POST requests for the majority of the library.

The streaming API requests are still managed with `async-http`.

