### PR TITLE
Fix parameter passing to the REST API through GET requests

### DIFF
--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -81,10 +81,8 @@ module Shodanz
         # build up url string based on special params
         url = "#{@url}#{path}?key=#{@key}"
         # special params
-        %w[query ips hostnames].each do |param|
-          if (value = params.delete(param))
-            url += "&#{param}=#{value}"
-          end
+        params.each do |param,value|
+          url += "&#{param}=#{value}" unless value.is_a?(Array) && value.empty?
         end
         resp = @internet.get(url)
 

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -82,7 +82,7 @@ module Shodanz
         url = "#{@url}#{path}?key=#{@key}"
         # special params
         params.each do |param,value|
-          url += "&#{param}=#{value}" unless value.is_a?(Array) && value.empty?
+          url += "&#{param}=#{value}" unless value.is_a?(String) && value.empty?
         end
         resp = @internet.get(url)
 


### PR DESCRIPTION
# The bug

In the `getter` method, when the GET request is built, the only parameters it uses from params are `query ips hostnames`, from the REST API reference, other parameters like the page number (optional), and minify parameter are also supported.

Example:
```
client = Shodanz.client.new(key: 'KEY_HERE');

client.host_search('irc', page: 1)
```
inside the `getter` method in apis/utils.rb
`params = {"page"=>1, "minify"=>true, "facets"=>""}`
url sent to @internet.get : `https://api.shodan.io/shodan/host/search?key=KEY_HERE&query=irc`
page is not sent! and I always get the first page, even if I set page to another value.

# The fix

Since `params` are sent without checking the keys in `POST` requests (see the `poster` method), I also constructed the request url directly from the data present in `params`.

# First PR

Sorry if this PR is off-topic, it's my first time contributing to this gem