### PR TITLE
Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  member: 
+  member:
   push:
     branches:
     - master
@@ -12,18 +12,18 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Ruby 2.6
+    - name: Set up Ruby 2.7
       uses: actions/setup-ruby@v1
       with:
-        ruby-version: 2.6.x
+        ruby-version: 2.7.x
     - name: Rspec
-      env: 
+      env:
         SHODAN_API_KEY: ${{secrets.SHODAN_API_KEY}}
       run: |
         gem install bundler
         bundle install --jobs 4 --retry 3
         bundle exec rspec
-        
+

--- a/lib/shodanz/apis/exploits.rb
+++ b/lib/shodanz/apis/exploits.rb
@@ -45,24 +45,24 @@ module Shodanz
       #   api.search("SQL", port: 443)
       #   api.search(port: 22)
       #   api.search(type: "dos")
-      def search(query = '', page: 1, **params)
+      def search(query = '', facets: {}, page: 1, **params)
         params[:query] = query
-        params = turn_into_query(params)
-        facets = turn_into_facets(facets)
+        params = turn_into_query(**params)
+        facets = turn_into_facets(**facets)
         params[:page] = page
-        get('search', params.merge(facets))
+        get('search', **params.merge(**facets))
       end
 
       # This method behaves identical to the "/search" method with
       # the difference that it doesn't return any results.
       # == Example
       #   api.count(type: "dos")
-      def count(query = '', page: 1, **params)
+      def count(query = '', facets: {}, page: 1, **params)
         params[:query] = query
-        params = turn_into_query(params)
-        facets = turn_into_facets(params)
+        params = turn_into_query(**params)
+        facets = turn_into_facets(**facets)
         params[:page] = page
-        get('count', params.merge(facets))
+        get('count', **params.merge(**facets))
       end
     end
   end

--- a/lib/shodanz/apis/rest.rb
+++ b/lib/shodanz/apis/rest.rb
@@ -49,7 +49,7 @@ module Shodanz
       #   # Only return the list of ports and the general host information, no banners.
       #   rest_api.host("8.8.8.8", minify: true)
       def host(ip, **params)
-        get("shodan/host/#{ip}", params)
+        get("shodan/host/#{ip}", **params)
       end
 
       # This method behaves identical to "/shodan/host/search" with the only
@@ -64,9 +64,9 @@ module Shodanz
       #   rest_api.host_count("apache", country: "US", state: "MI", city: "Detroit")
       def host_count(query = '', facets: {}, **params)
         params[:query] = query
-        params = turn_into_query(params)
-        facets = turn_into_facets(facets)
-        get('shodan/host/count', params.merge(facets))
+        params = turn_into_query(**params)
+        facets = turn_into_facets(**facets)
+        get('shodan/host/count', **params.merge(**facets))
       end
 
       # Search Shodan using the same query syntax as the website and use facets
@@ -75,19 +75,19 @@ module Shodanz
       #   rest_api.host_search("apache", country: "US", facets: { city: "Detroit" }, page: 1, minify: false)
       def host_search(query = '', facets: {}, page: 1, minify: true, **params)
         params[:query] = query
-        params = turn_into_query(params)
-        facets = turn_into_facets(facets)
+        params = turn_into_query(**params)
+        facets = turn_into_facets(**facets)
         params[:page] = page
         params[:minify] = minify
-        get('shodan/host/search', params.merge(facets))
+        get('shodan/host/search', **params.merge(**facets))
       end
 
       # This method lets you determine which filters are being used by
       # the query string and what parameters were provided to the filters.
       def host_search_tokens(query = '', **params)
         params[:query] = query
-        params = turn_into_query(params)
-        get('shodan/host/search/tokens', params)
+        params = turn_into_query(**params)
+        get('shodan/host/search/tokens', **params)
       end
 
       # This method returns a list of port numbers that the crawlers are looking for.
@@ -122,8 +122,8 @@ module Shodanz
       #   rest_api.crawl_for(port: 80, protocol: "http")
       def crawl_for(**params)
         params[:query] = ''
-        params = turn_into_query(params)
-        post('shodan/scan/internet', params)
+        params = turn_into_query(**params)
+        post('shodan/scan/internet', **params)
       end
 
       # Check the progress of a previously submitted scan request.
@@ -133,21 +133,21 @@ module Shodanz
 
       # Use this method to obtain a list of search queries that users have saved in Shodan.
       def community_queries(**params)
-        get('shodan/query', params)
+        get('shodan/query', **params)
       end
 
       # Use this method to search the directory of search queries that users have saved in Shodan.
       def search_for_community_query(query, **params)
         params[:query] = query
-        params = turn_into_query(params)
-        get('shodan/query/search', params)
+        params = turn_into_query(**params)
+        get('shodan/query/search', **params)
       end
 
       # Use this method to obtain a list of popular tags for the saved search queries in Shodan.
       def popular_query_tags(size = 10)
         params = {}
         params[:size] = size
-        get('shodan/query/tags', params)
+        get('shodan/query/tags', **params)
       end
 
       # Returns information about the Shodan account linked to this API key.

--- a/lib/shodanz/apis/streaming.rb
+++ b/lib/shodanz/apis/streaming.rb
@@ -54,7 +54,7 @@ module Shodanz
       #     puts data
       #   end
       def banners(**params)
-        slurp_stream('shodan/banners', params) do |data|
+        slurp_stream('shodan/banners', **params) do |data|
           yield data
         end
       end
@@ -67,7 +67,7 @@ module Shodanz
       #     puts data
       #   end
       def banners_within_asns(*asns, **params)
-        slurp_stream("shodan/asn/#{asns.join(',')}", params) do |data|
+        slurp_stream("shodan/asn/#{asns.join(',')}", **params) do |data|
           yield data
         end
       end

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -14,32 +14,32 @@ module Shodanz
     module Utils
       # Perform a direct GET HTTP request to the REST API.
       def get(path, **params)
-        return sync_get(path, params) unless Async::Task.current?
+        return sync_get(path, **params) unless Async::Task.current?
 
-        async_get(path, params)
+        async_get(path, **params)
       end
 
       # Perform a direct POST HTTP request to the REST API.
       def post(path, **params)
-        return sync_post(path, params) unless Async::Task.current?
+        return sync_post(path, **params) unless Async::Task.current?
 
-        async_post(path, params)
+        async_post(path, **params)
       end
 
       # Perform the main function of consuming the streaming API.
       def slurp_stream(path, **params)
         if Async::Task.current?
-          async_slurp_stream(path, params) do |result|
+          async_slurp_stream(path, **params) do |result|
             yield result
           end
         else
-          sync_slurp_stream(path, params) do |result|
+          sync_slurp_stream(path, **params) do |result|
             yield result
           end
         end
       end
 
-      def turn_into_query(params)
+      def turn_into_query(**params)
         filters = params.reject { |key, _| key == :query }
         filters.each do |key, value|
           params[:query] << " #{key}:#{value}"
@@ -47,7 +47,7 @@ module Shodanz
         params.select { |key, _| key == :query }
       end
 
-      def turn_into_facets(facets)
+      def turn_into_facets(**facets)
         return {} if facets.nil?
 
         filters = facets.reject { |key, _| key == :facets }
@@ -135,37 +135,37 @@ module Shodanz
 
       def async_get(path, **params)
         Async::Task.current.async do
-          getter(path, params)
+          getter(path, **params)
         end
       end
 
       def sync_get(path, **params)
         Async do
-          getter(path, params)
+          getter(path, **params)
         end.wait
       end
 
       def async_post(path, **params)
         Async::Task.current.async do
-          poster(path, params)
+          poster(path, **params)
         end
       end
 
       def sync_post(path, **params)
         Async do
-          poster(path, params)
+          poster(path, **params)
         end.wait
       end
 
       def async_slurp_stream(path, **params)
         Async::Task.current.async do
-          slurper(path, params) { |data| yield data }
+          slurper(path, **params) { |data| yield data }
         end
       end
 
       def sync_slurp_stream(path, **params)
         Async do
-          slurper(path, params) { |data| yield data }
+          slurper(path, **params) { |data| yield data }
         end.wait
       end
     end

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Shodanz::API::REST do
 
   before(:each) do
     # try to avoid rate limit
-    sleep 1
+    sleep 3
   end
 
   describe '#info' do


### PR DESCRIPTION
Aims to fix #32 

Use (kind'a ugly) explicit double splats everywhere to remove 2.7 warnings.

