### PR TITLE
Fix minor spelling mistake in error message

### DIFF
--- a/lib/shodanz/errors.rb
+++ b/lib/shodanz/errors.rb
@@ -15,7 +15,7 @@ module Shodanz
     end
 
     class NoAPIKey < StandardError
-      def initialize(msg = 'No API key has been found or provided! ( setup your SHODAN_API_KEY environment varialbe )')
+      def initialize(msg = 'No API key has been found or provided! ( setup your SHODAN_API_KEY environment variable )')
         super
       end
     end


### PR DESCRIPTION
Small spelling mistake in the error message when no API key is provided, `variable` instead of `varialbe`.