### PR TITLE
Clearly separate URL params and JSON body

### DIFF
--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -349,7 +349,7 @@ RSpec.describe Shodanz::API::REST do
       end
       expect(resp).to be_a(Hash)
       expect(resp['Content-Length']).to be_a(String)
-      expect(resp['Content-Length']).to eq('0')
+      expect(resp['Content-Length']).to eq('')
       # TODO maybe specify a content-type?
       expect(resp['Content-Type']).to be_a(String)
       expect(resp['Content-Type']).to eq('')

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -10,6 +10,32 @@ RSpec.describe Shodanz::API::REST do
     sleep 3
   end
 
+  describe '#scan' do
+    def check
+      if Async::Task.current?
+        resp = @client.scan("1.1.1.1").wait
+      else
+        resp = @client.scan("1.1.1.1")
+      end
+      expect(resp).to be_a(Hash)
+      expect(resp["count"]).to be_a(Integer)
+      expect(resp["id"]).to be_a(String)
+      expect(resp["credits_left"]).to be_a(Integer)
+    end
+
+    describe 'scans host on the internet' do
+      it 'works synchronously' do
+        check
+      end
+
+      it 'works asynchronously' do
+        Async do
+          check
+        end
+      end
+    end
+  end
+
   describe '#info' do
     def check
       if Async::Task.current?

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -348,9 +348,6 @@ RSpec.describe Shodanz::API::REST do
         resp = @client.http_headers
       end
       expect(resp).to be_a(Hash)
-      # TODO figure out why there are two content length headers?
-      expect(resp['Content_Length']).to be_a(String)
-      expect(resp['Content_Length']).to eq('0')
       expect(resp['Content-Length']).to be_a(String)
       expect(resp['Content-Length']).to eq('0')
       # TODO maybe specify a content-type?


### PR DESCRIPTION
Aims to fix #48 

Cloudflare was enabled for Shodan's API, and certain endpoints that used to accept URL params _and_ JSON bodies interchangeably now only accept one or the other.