### PR TITLE
Fix failing CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       env:
         SHODAN_API_KEY: ${{secrets.SHODAN_API_KEY}}
       run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
+        gem install bundler:2.2.33
+        bundle _2.2.33_ install --jobs 4 --retry 3
         bundle exec rspec
 


### PR DESCRIPTION
CI has been [failing](https://github.com/picatz/shodanz/runs/5229399653?check_suite_focus=true) for a while now due to a version problem with `bundle`/`bundler`. This PR aims to fix that.

```console
Run gem install bundler
Successfully installed bundler-2.3.7
Parsing documentation for bundler-2.3.7
Installing ri documentation for bundler-2.3.7
Done installing documentation for bundler after 0 seconds
1 gem installed
Fetching gem metadata from https://rubygems.org/.......
Resolving dependencies...
Bundler could not find compatible versions for gem "bundler":
  In Gemfile:
    bundler (~> 2.2.0)

  Current Bundler version:
    bundler (2.3.7)

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:2.2.33` and rerun
bundler using `bundle _2.2.33_ install --jobs 4 --retry 3`
```