### PR TITLE
Fix `scan` method and tests

### DIFF
--- a/lib/shodanz/apis/rest.rb
+++ b/lib/shodanz/apis/rest.rb
@@ -108,7 +108,7 @@ module Shodanz
       #
       # IP, IPs or netblocks (in CIDR notation) that should get crawled.
       def scan(*ips)
-        post('shodan/scan', ips: ips.join(','))
+        post('shodan/scan', body: {ips: ips.join(',')})
       end
 
       # Use this method to request Shodan to crawl the Internet for a specific port.

--- a/lib/shodanz/apis/utils.rb
+++ b/lib/shodanz/apis/utils.rb
@@ -107,20 +107,25 @@ module Shodanz
         resp&.close
       end
 
-      def poster(path, one_shot: false, params: nil, body: nil)
+      def poster(path, params: nil, body: nil)
         # param keys should all be strings
         params = params.transform_keys(&:to_s)
         # and the key param is constant
         params["key"] = @key
         # encode as a URL string
         params = URI.encode_www_form(params)
-        # optional JSON body string
-        json_body = body.nil? ? nil : JSON.dump(body)
         # build URL path
-        path = "/#{path}?#{params}" 
+        path = "/#{path}?#{params}"
+
+        headers = nil
+
+        if body
+          body = URI.encode_www_form(body)
+          headers = [['Content-Type', 'application/x-www-form-urlencoded']]
+        end
 
         # make POST request to server
-        resp = @client.post(path, nil, json_body)
+        resp = @client.post(path, headers, body)
 
         if resp.success?
           json = JSON.parse(resp.body.join)

--- a/lib/shodanz/version.rb
+++ b/lib/shodanz/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shodanz
-  VERSION = '2.0.7'
+  VERSION = '2.0.8'
 end

--- a/spec/exploits_api_spec.rb
+++ b/spec/exploits_api_spec.rb
@@ -14,10 +14,8 @@ RSpec.describe Shodanz::API::Exploits do
 
   describe '#search' do
     it 'should search across a variety of data sources for exploits' do
-      reactor.async do
-        resp = @client.search("SQL", port: 443).wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.search("SQL", port: 443).wait
+      expect(resp).to be_a(Hash)
     end
   end
 end

--- a/spec/rest_api_spec.rb
+++ b/spec/rest_api_spec.rb
@@ -14,22 +14,28 @@ RSpec.describe Shodanz::API::REST do
 
   describe '#scan' do
     it 'should be able to scan a host on the internet' do
-      reactor.async do
-        resp = @client.scan("1.1.1.1").wait
-        expect(resp).to be_a(Hash)
-        expect(resp["count"]).to be_a(Integer)
-        expect(resp["id"]).to be_a(String)
-        expect(resp["credits_left"]).to be_a(Integer)
-      end
+      resp = @client.scan("1.1.1.1").wait
+      expect(resp).to be_a(Hash)
+      expect(resp["count"]).to be_a(Integer)
+      expect(resp["count"]).to eq(1)
+      expect(resp["id"]).to be_a(String)
+      expect(resp["credits_left"]).to be_a(Integer)
+    end
+
+    it 'should be able to scan multiple hosts on the internet' do
+      resp = @client.scan("1.1.1.1", "8.8.8.8").wait
+      expect(resp).to be_a(Hash)
+      expect(resp["count"]).to be_a(Integer)
+      expect(resp["count"]).to eq(2)
+      expect(resp["id"]).to be_a(String)
+      expect(resp["credits_left"]).to be_a(Integer)
     end
   end
 
   describe '#info' do
     it 'returns info about the underlying token' do
-      reactor.async do
-        resp = @client.info.wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.info.wait
+      expect(resp).to be_a(Hash)
     end
   end
 
@@ -37,10 +43,8 @@ RSpec.describe Shodanz::API::REST do
     let(:ip) { "8.8.8.8" }
 
     it 'returns all services that have been found on the given host IP' do
-      reactor.async do
-        resp = @client.host(ip).wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.host(ip).wait
+      expect(resp).to be_a(Hash)
     end
   end
 
@@ -48,10 +52,8 @@ RSpec.describe Shodanz::API::REST do
     let(:query) { "apache" }
 
     it 'returns the total number of results that matches a given query' do
-      reactor.async do
-        resp = @client.host_count(query).wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.host_count(query).wait
+      expect(resp).to be_a(Hash)
     end
   end
 
@@ -59,10 +61,8 @@ RSpec.describe Shodanz::API::REST do
     let(:query) { "apache" }
 
     it 'returns the total number of results that matches a given query' do
-      reactor.async do
-        resp = @client.host_search(query).wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.host_search(query).wait
+      expect(resp).to be_a(Hash)
     end
   end
 
@@ -70,67 +70,57 @@ RSpec.describe Shodanz::API::REST do
     let(:query) { "apache" }
 
     it 'returns a parsed version of the query' do
-      reactor.async do
-        resp = @client.host_search_tokens(query).wait
-        expect(resp).to be_a(Hash)
-        expect(resp['attributes']).to be_a(Hash)
-        expect(resp['errors']).to be_a(Array)
-        expect(resp['filters']).to be_a(Array)
-        expect(resp['string']).to be_a(String)
-        expect(resp['string']).to eq(query)
-      end
+      resp = @client.host_search_tokens(query).wait
+      expect(resp).to be_a(Hash)
+      expect(resp['attributes']).to be_a(Hash)
+      expect(resp['errors']).to be_a(Array)
+      expect(resp['filters']).to be_a(Array)
+      expect(resp['string']).to be_a(String)
+      expect(resp['string']).to eq(query)
     end
   end
 
   describe '#ports' do
     it 'returns a list of port numbers that the crawlers are looking for' do
-      reactor.async do
-        resp = @client.ports.wait
-        expect(resp).to be_a(Array)
-      end
+      resp = @client.ports.wait
+      expect(resp).to be_a(Array)
     end
   end
 
   describe '#protocols' do
     it 'returns all protocols that can be used when performing on-demand scans' do
-      reactor.async do
-        resp = @client.protocols.wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.protocols.wait
+      expect(resp).to be_a(Hash)
     end
   end
 
   describe '#profile' do
     it 'returns information about the shodan account' do
-      reactor.async do
-        resp = @client.profile.wait
-        expect(resp).to be_a(Hash)
-        expect(resp["member"]).to be(true).or be(false)
-        expect(resp["credits"]).to be_a(Integer)
-        expect(resp["created"]).to be_a(String)
-        expect(resp.key?("display_name")).to be(true)
-      end
+      resp = @client.profile.wait
+      expect(resp).to be_a(Hash)
+      expect(resp["member"]).to be(true).or be(false)
+      expect(resp["credits"]).to be_a(Integer)
+      expect(resp["created"]).to be_a(String)
+      expect(resp.key?("display_name")).to be(true)
     end
   end
 
   describe '#community_queries' do
     it 'obtains a list of search queries that users have saved' do
-      reactor.async do
-        resp = @client.community_queries.wait
+      resp = @client.community_queries.wait
 
-        expect(resp).to be_a(Hash)
-        expect(resp['total']).to be_a(Integer)
-        expect(resp['matches']).to be_a(Array)
+      expect(resp).to be_a(Hash)
+      expect(resp['total']).to be_a(Integer)
+      expect(resp['matches']).to be_a(Array)
 
-        example_match = resp['matches'].first
+      example_match = resp['matches'].first
 
-        expect(example_match['votes']).to be_a(Integer)
-        expect(example_match['description']).to be_a(String)
-        expect(example_match['tags']).to be_a(Array)
-        expect(example_match['timestamp']).to be_a(String)
-        expect(example_match['title']).to be_a(String)
-        expect(example_match['query']).to be_a(String)
-      end
+      expect(example_match['votes']).to be_a(Integer)
+      expect(example_match['description']).to be_a(String)
+      expect(example_match['tags']).to be_a(Array)
+      expect(example_match['timestamp']).to be_a(String)
+      expect(example_match['title']).to be_a(String)
+      expect(example_match['query']).to be_a(String)
     end
   end
 
@@ -138,22 +128,20 @@ RSpec.describe Shodanz::API::REST do
     let(:query) { "apache" }
 
     it 'search the directory of search queries that users have saved' do
-      reactor.async do
-        resp = @client.search_for_community_query(query).wait
+      resp = @client.search_for_community_query(query).wait
 
-        expect(resp).to be_a(Hash)
-        expect(resp['total']).to be_a(Integer)
-        expect(resp['matches']).to be_a(Array)
+      expect(resp).to be_a(Hash)
+      expect(resp['total']).to be_a(Integer)
+      expect(resp['matches']).to be_a(Array)
 
-        example_match = resp['matches'].first
+      example_match = resp['matches'].first
 
-        expect(example_match['votes']).to be_a(Integer)
-        expect(example_match['description']).to be_a(String)
-        expect(example_match['tags']).to be_a(Array)
-        expect(example_match['timestamp']).to be_a(String)
-        expect(example_match['title']).to be_a(String)
-        expect(example_match['query']).to be_a(String)
-      end
+      expect(example_match['votes']).to be_a(Integer)
+      expect(example_match['description']).to be_a(String)
+      expect(example_match['tags']).to be_a(Array)
+      expect(example_match['timestamp']).to be_a(String)
+      expect(example_match['title']).to be_a(String)
+      expect(example_match['query']).to be_a(String)
     end
   end
 
@@ -161,10 +149,8 @@ RSpec.describe Shodanz::API::REST do
     let(:hostname) { "google.com" }
 
     it 'resolves domains to ip addresses' do
-      reactor.async do
-        resp = @client.resolve(hostname).wait
-        expect(resp).to be_a(Hash)
-      end
+      resp = @client.resolve(hostname).wait
+      expect(resp).to be_a(Hash)
     end
   end
 
@@ -172,37 +158,31 @@ RSpec.describe Shodanz::API::REST do
     let(:ip) { '8.8.8.8' }
 
     it 'resolves ip addresses to domains' do
-      reactor.async do
-        resp = @client.reverse_lookup(ip).wait
-        expect(resp).to be_a(Hash)
-        expect('8.8.8.8').not_to be nil
-      end
+      resp = @client.reverse_lookup(ip).wait
+      expect(resp).to be_a(Hash)
+      expect('8.8.8.8').not_to be nil
     end
   end
 
   describe '#http_headers' do
     it 'shows the HTTP headers that your client sends when connecting to a webserver' do
-      reactor.async do
-        resp = @client.http_headers.wait
+      resp = @client.http_headers.wait
 
-        expect(resp).to be_a(Hash)
-        expect(resp['Content-Length']).to be_a(String)
-        expect(resp['Content-Length']).to eq('')
-        # TODO maybe specify a content-type?
-        expect(resp['Content-Type']).to be_a(String)
-        expect(resp['Content-Type']).to eq('')
-        expect(resp['Host']).to be_a(String)
-        expect(resp['Host']).to eq('api.shodan.io')
-      end
+      expect(resp).to be_a(Hash)
+      expect(resp['Content-Length']).to be_a(String)
+      expect(resp['Content-Length']).to eq('')
+      # TODO maybe specify a content-type?
+      expect(resp['Content-Type']).to be_a(String)
+      expect(resp['Content-Type']).to eq('')
+      expect(resp['Host']).to be_a(String)
+      expect(resp['Host']).to eq('api.shodan.io')
     end
   end
 
   describe '#my_ip' do
     it 'shows the current IP address as seen from the internet' do
-      reactor.async do
-        resp = @client.my_ip.wait
-        expect(resp).to be_a(String)
-      end
+      resp = @client.my_ip.wait
+      expect(resp).to be_a(String)
     end
   end
 end

--- a/spec/streaming_api_spec.rb
+++ b/spec/streaming_api_spec.rb
@@ -14,10 +14,8 @@ RSpec.describe Shodanz::API::Streaming do
 
   describe '#banners' do
     it "should stream any banner data Shodan collects" do
-      reactor.async do
-        @client.banners(limit: 1) do |banner|
-          expect(banner).to be_a(Hash)
-        end
+      @client.banners(limit: 1) do |banner|
+        expect(banner).to be_a(Hash)
       end
     end
   end


### PR DESCRIPTION
This PR aims to fix #85 by allowing the `scan` method to *actually* scan multiple IP addresses. It also fixes the tests to allow these errors to be surfaced through daily tests in the future.